### PR TITLE
Fix repository review: i18n labels and adapter timer methods

### DIFF
--- a/admin/i18n/de.json
+++ b/admin/i18n/de.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Erstellen Sie Rohmesszustände",
-	"Grohe email / username": "Grohe E-Mail/Benutzername",
+	"Grohe email / username": "Grohe E-Mail / Benutzername",
 	"Grohe password": "Grohe-Passwort",
 	"Polling interval (seconds)": "Abfrageintervall (Sekunden)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Zu häufige Abfragen können HTTP 403-Fehler von der Grohe-API verursachen. Empfohlen: 300s oder höher."
+	"pollIntervalHelp": "Zu häufiges Polling kann zu HTTP 403-Fehlern der Grohe-API führen. Empfohlen: 300s oder höher. Bei Fehlern wird das Intervall automatisch erhöht (bis 1h) und nach erfolgreichem Abruf zurückgesetzt.",
+	"Create raw measurement states": "Rohdaten-States erstellen"
 }

--- a/admin/i18n/en.json
+++ b/admin/i18n/en.json
@@ -2,6 +2,6 @@
 	"Grohe email / username": "Grohe email / username",
 	"Grohe password": "Grohe password",
 	"Polling interval (seconds)": "Polling interval (seconds)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.",
+	"pollIntervalHelp": "Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher. On errors the interval increases automatically (up to 1h) and resets after a successful poll.",
 	"Create raw measurement states": "Create raw measurement states"
 }

--- a/admin/i18n/es.json
+++ b/admin/i18n/es.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Crear estados de medición sin procesar",
-	"Grohe email / username": "Correo electrónico/nombre de usuario de Grohe",
+	"Grohe email / username": "Correo electrónico / nombre de usuario de Grohe",
 	"Grohe password": "Contraseña de Grohe",
 	"Polling interval (seconds)": "Intervalo de sondeo (segundos)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Un sondeo demasiado frecuente puede provocar errores HTTP 403 en la API de Grohe. Recomendado: 300s o más."
+	"pollIntervalHelp": "Un sondeo demasiado frecuente puede provocar errores HTTP 403 en la API de Grohe. Recomendado: 300s o más. En caso de errores, el intervalo se incrementa automáticamente (hasta 1h) y se restablece tras una consulta exitosa.",
+	"Create raw measurement states": "Crear estados de medición sin procesar"
 }

--- a/admin/i18n/fr.json
+++ b/admin/i18n/fr.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Créer des états de mesure bruts",
 	"Grohe email / username": "E-mail / nom d'utilisateur Grohe",
 	"Grohe password": "Mot de passe Grohe",
 	"Polling interval (seconds)": "Intervalle d'interrogation (secondes)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Des interrogations trop fréquentes peuvent provoquer des erreurs HTTP 403 de la part de l'API Grohe. Recommandé : 300 s ou plus."
+	"pollIntervalHelp": "Des interrogations trop fréquentes peuvent provoquer des erreurs HTTP 403 de l'API Grohe. Recommandé : 300s ou plus. En cas d'erreurs, l'intervalle augmente automatiquement (jusqu'à 1h) et se réinitialise après une interrogation réussie.",
+	"Create raw measurement states": "Créer des états de mesure bruts"
 }

--- a/admin/i18n/it.json
+++ b/admin/i18n/it.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Creare stati di misurazione grezzi",
-	"Grohe email / username": "E-mail/nome utente Grohe",
-	"Grohe password": "Parola d'ordine Grohe",
+	"Grohe email / username": "E-mail / nome utente Grohe",
+	"Grohe password": "Password Grohe",
 	"Polling interval (seconds)": "Intervallo di polling (secondi)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Un polling troppo frequente può causare errori HTTP 403 dall'API Grohe. Consigliato: 300 o superiore."
+	"pollIntervalHelp": "Un polling troppo frequente può causare errori HTTP 403 dall'API Grohe. Consigliato: 300s o superiore. In caso di errori, l'intervallo aumenta automaticamente (fino a 1h) e si ripristina dopo un polling riuscito.",
+	"Create raw measurement states": "Creare stati di misurazione grezzi"
 }

--- a/admin/i18n/nl.json
+++ b/admin/i18n/nl.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Creëer onbewerkte meetstatussen",
 	"Grohe email / username": "Grohe e-mailadres / gebruikersnaam",
 	"Grohe password": "Grohe-wachtwoord",
 	"Polling interval (seconds)": "Polling-interval (seconden)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Te frequent pollen kan HTTP 403-fouten van de Grohe API veroorzaken. Aanbevolen: 300s of hoger."
+	"pollIntervalHelp": "Te frequent pollen kan HTTP 403-fouten van de Grohe API veroorzaken. Aanbevolen: 300s of hoger. Bij fouten wordt het interval automatisch verhoogd (tot 1u) en hersteld na een succesvolle poll.",
+	"Create raw measurement states": "Onbewerkte meetstatussen aanmaken"
 }

--- a/admin/i18n/pl.json
+++ b/admin/i18n/pl.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Twórz surowe stany pomiarowe",
 	"Grohe email / username": "Adres e-mail / nazwa użytkownika Grohe",
 	"Grohe password": "Hasło Grohe",
 	"Polling interval (seconds)": "Interwał odpytywania (sekundy)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Zbyt częste odpytywanie może powodować błędy HTTP 403 z API Grohe. Zalecane: 300s lub więcej."
+	"pollIntervalHelp": "Zbyt częste odpytywanie może powodować błędy HTTP 403 z API Grohe. Zalecane: 300s lub więcej. W przypadku błędów interwał zwiększa się automatycznie (do 1h) i resetuje po udanym odpytaniu.",
+	"Create raw measurement states": "Twórz surowe stany pomiarowe"
 }

--- a/admin/i18n/pt.json
+++ b/admin/i18n/pt.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Crie estados de medição brutos",
 	"Grohe email / username": "E-mail / nome de usuário Grohe",
 	"Grohe password": "Senha Grohe",
 	"Polling interval (seconds)": "Intervalo de pesquisa (segundos)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Pesquisas muito frequentes podem causar erros HTTP 403 da API Grohe. Recomendado: 300 ou superior."
+	"pollIntervalHelp": "Pesquisas muito frequentes podem causar erros HTTP 403 da API Grohe. Recomendado: 300s ou superior. Em caso de erros, o intervalo aumenta automaticamente (até 1h) e é redefinido após uma pesquisa bem-sucedida.",
+	"Create raw measurement states": "Criar estados de medição brutos"
 }

--- a/admin/i18n/ru.json
+++ b/admin/i18n/ru.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Создание необработанных состояний измерений",
 	"Grohe email / username": "Адрес электронной почты / имя пользователя Grohe",
-	"Grohe password": "Пароль Гроэ",
+	"Grohe password": "Пароль Grohe",
 	"Polling interval (seconds)": "Интервал опроса (секунды)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Слишком частый опрос может привести к ошибке HTTP 403 от Grohe API. Рекомендуется: 300 с или выше."
+	"pollIntervalHelp": "Слишком частый опрос может привести к ошибкам HTTP 403 от Grohe API. Рекомендуется: 300с или выше. При ошибках интервал автоматически увеличивается (до 1ч) и сбрасывается после успешного опроса.",
+	"Create raw measurement states": "Создание необработанных состояний измерений"
 }

--- a/admin/i18n/uk.json
+++ b/admin/i18n/uk.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "Створення необроблених станів вимірювання",
-	"Grohe email / username": "Електронна адреса/ім’я користувача Grohe",
+	"Grohe email / username": "Електронна адреса / ім'я користувача Grohe",
 	"Grohe password": "Пароль Grohe",
 	"Polling interval (seconds)": "Інтервал опитування (секунди)",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "Надто часте опитування може спричинити помилки HTTP 403 від Grohe API. Recommended: 300s or higher."
+	"pollIntervalHelp": "Надто часте опитування може спричинити помилки HTTP 403 від Grohe API. Рекомендовано: 300с або вище. При помилках інтервал автоматично збільшується (до 1год) і скидається після успішного опитування.",
+	"Create raw measurement states": "Створення необроблених станів вимірювання"
 }

--- a/admin/i18n/zh-cn.json
+++ b/admin/i18n/zh-cn.json
@@ -1,7 +1,7 @@
 {
-	"Create raw measurement states": "创建原始测量状态",
 	"Grohe email / username": "高仪电子邮件/用户名",
 	"Grohe password": "高仪密码",
 	"Polling interval (seconds)": "轮询间隔（秒）",
-	"Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher.": "过于频繁的轮询可能会导致 Grohe API 出现 HTTP 403 错误。建议：300s 或更高。"
+	"pollIntervalHelp": "过于频繁的轮询可能会导致 Grohe API 出现 HTTP 403 错误。建议：300秒或更高。出错时，间隔会自动增加（最多1小时），成功轮询后会重置。",
+	"Create raw measurement states": "创建原始测量状态"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,49 +1,46 @@
 {
-  "type": "panel",
-  "i18n": true,
-  "items": {
-    "email": {
-      "type": "text",
-      "label": { "en": "Grohe email / username", "de": "Grohe E-Mail / Benutzername" },
-      "xs": 12,
-      "sm": 12,
-      "md": 6,
-      "lg": 6,
-      "xl": 6
-    },
-    "password": {
-      "type": "password",
-      "label": { "en": "Grohe password", "de": "Grohe Passwort" },
-      "xs": 12,
-      "sm": 12,
-      "md": 6,
-      "lg": 6,
-      "xl": 6
-    },
-    "pollInterval": {
-      "type": "number",
-      "label": { "en": "Polling interval (seconds)", "de": "Abfrageintervall (Sekunden)" },
-      "help": {
-        "en": "Too frequent polling may cause HTTP 403 errors from the Grohe API. Recommended: 300s or higher. On errors the interval increases automatically (up to 1h) and resets after a successful poll.",
-        "de": "Zu häufiges Polling kann zu HTTP 403-Fehlern der Grohe-API führen. Empfohlen: 300s oder höher. Bei Fehlern wird das Intervall automatisch erhöht (bis 1h) und nach erfolgreichem Abruf zurückgesetzt."
-      },
-      "min": 60,
-      "default": 300,
-      "xs": 12,
-      "sm": 6,
-      "md": 4,
-      "lg": 3,
-      "xl": 2
-    },
-    "rawStates": {
-      "type": "checkbox",
-      "label": { "en": "Create raw measurement states", "de": "Rohdaten-States erstellen" },
-      "default": false,
-      "xs": 12,
-      "sm": 6,
-      "md": 4,
-      "lg": 3,
-      "xl": 2
-    }
-  }
+	"type": "panel",
+	"i18n": true,
+	"items": {
+		"email": {
+			"type": "text",
+			"label": "Grohe email / username",
+			"xs": 12,
+			"sm": 12,
+			"md": 6,
+			"lg": 6,
+			"xl": 6
+		},
+		"password": {
+			"type": "password",
+			"label": "Grohe password",
+			"xs": 12,
+			"sm": 12,
+			"md": 6,
+			"lg": 6,
+			"xl": 6
+		},
+		"pollInterval": {
+			"type": "number",
+			"label": "Polling interval (seconds)",
+			"help": "pollIntervalHelp",
+			"min": 60,
+			"default": 300,
+			"xs": 12,
+			"sm": 6,
+			"md": 4,
+			"lg": 3,
+			"xl": 2
+		},
+		"rawStates": {
+			"type": "checkbox",
+			"label": "Create raw measurement states",
+			"default": false,
+			"xs": 12,
+			"sm": 6,
+			"md": 4,
+			"lg": 3,
+			"xl": 2
+		}
+	}
 }

--- a/main.js
+++ b/main.js
@@ -216,9 +216,9 @@ class GroheSmarthome extends utils.Adapter {
 	 */
 	_schedulePoll() {
 		if (this.pollTimer) {
-			clearTimeout(this.pollTimer);
+			this.clearTimeout(this.pollTimer);
 		}
-		this.pollTimer = setTimeout(async () => {
+		this.pollTimer = this.setTimeout(async () => {
 			await this.pollDevices();
 			this._schedulePoll();
 		}, this.currentPollInterval * 1000);
@@ -1034,7 +1034,7 @@ class GroheSmarthome extends utils.Adapter {
 	onUnload(callback) {
 		try {
 			if (this.pollTimer) {
-				clearTimeout(this.pollTimer);
+				this.clearTimeout(this.pollTimer);
 			}
 			this.client = null;
 			callback();


### PR DESCRIPTION
Addresses two issues from ioBroker repository review (PR #5518):

1. i18n: Replaced inline {en, de} label/help objects in jsonConfig.json with simple string references resolved via admin/i18n/*.json files. Added pollIntervalHelp key with backoff info to all 11 languages.

2. Timers: Replaced native setTimeout/clearTimeout with adapter this.setTimeout/this.clearTimeout which ensures proper cleanup on unload and respects adapter lifecycle.

https://claude.ai/code/session_019nEL46eRDipvMnA22QymRL