### PR TITLE
Add Grohe Sense Guard integration for ESPHome

### DIFF
--- a/esphome/components/grohe_sense_guard/__init__.py
+++ b/esphome/components/grohe_sense_guard/__init__.py
@@ -8,7 +8,7 @@ AUTO_LOAD = ["sensor", "binary_sensor", "switch", "number", "text_sensor"]
 
 grohe_ns = cg.esphome_ns.namespace("grohe_sense_guard")
 GroheSenseGuard = grohe_ns.class_(
-    "GroheSenseGuard", cg.Component, uart.UARTDevice
+    "GroheSenseGuard", cg.PollingComponent, uart.UARTDevice
 )
 
 CONF_GROHE_ID = "grohe_id"
@@ -20,7 +20,7 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("30s"))
 )
 
 

--- a/esphome/components/grohe_sense_guard/__init__.py
+++ b/esphome/components/grohe_sense_guard/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["sensor", "binary_sensor", "switch", "number", "text_sensor"]
+
+grohe_ns = cg.esphome_ns.namespace("grohe_sense_guard")
+GroheSenseGuard = grohe_ns.class_(
+    "GroheSenseGuard", cg.Component, uart.UARTDevice
+)
+
+CONF_GROHE_ID = "grohe_id"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(GroheSenseGuard),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/esphome/components/grohe_sense_guard/binary_sensor.py
+++ b/esphome/components/grohe_sense_guard/binary_sensor.py
@@ -1,0 +1,53 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import CONF_ID
+from . import grohe_ns, GroheSenseGuard, CONF_GROHE_ID
+
+CONF_VALVE_OPEN     = "valve_open"
+CONF_SNOOZE_ACTIVE  = "snooze_active"
+CONF_PRESSURE_TEST  = "pressure_test"
+CONF_SPRINKLER_MON  = "sprinkler_monday"
+CONF_SPRINKLER_TUE  = "sprinkler_tuesday"
+CONF_SPRINKLER_WED  = "sprinkler_wednesday"
+CONF_SPRINKLER_THU  = "sprinkler_thursday"
+CONF_SPRINKLER_FRI  = "sprinkler_friday"
+CONF_SPRINKLER_SAT  = "sprinkler_saturday"
+CONF_SPRINKLER_SUN  = "sprinkler_sunday"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_GROHE_ID): cv.use_id(GroheSenseGuard),
+        cv.Optional(CONF_VALVE_OPEN):    binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SNOOZE_ACTIVE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_PRESSURE_TEST): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_MON): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_TUE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_WED): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_THU): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_FRI): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_SAT): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_SPRINKLER_SUN): binary_sensor.binary_sensor_schema(),
+    }
+)
+
+_SETTERS = {
+    CONF_VALVE_OPEN:    "set_valve_open",
+    CONF_SNOOZE_ACTIVE: "set_snooze_active",
+    CONF_PRESSURE_TEST: "set_pressure_test",
+    CONF_SPRINKLER_MON: "set_sprinkler_monday",
+    CONF_SPRINKLER_TUE: "set_sprinkler_tuesday",
+    CONF_SPRINKLER_WED: "set_sprinkler_wednesday",
+    CONF_SPRINKLER_THU: "set_sprinkler_thursday",
+    CONF_SPRINKLER_FRI: "set_sprinkler_friday",
+    CONF_SPRINKLER_SAT: "set_sprinkler_saturday",
+    CONF_SPRINKLER_SUN: "set_sprinkler_sunday",
+}
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_GROHE_ID])
+    for conf_key, setter in _SETTERS.items():
+        if conf_key in config:
+            sens = await binary_sensor.new_binary_sensor(config[conf_key])
+            cg.add(getattr(hub, setter)(sens))

--- a/esphome/components/grohe_sense_guard/grohe_protocol.h
+++ b/esphome/components/grohe_sense_guard/grohe_protocol.h
@@ -24,7 +24,9 @@ static const uint8_t MSG_CONFIG_RESP   = 0x0C;
 
 // Flags
 static const uint8_t FLAG_READ         = 0x20;
-static const uint8_t FLAG_WRITE        = 0x60;
+// Note: 0x20 is used for BOTH reads (MCU broadcasts) and writes (app commands).
+// The MCU distinguishes commands from broadcasts via payload[6]=0x07 in write frames.
+static const uint8_t FLAG_WRITE        = 0x20;
 
 // Payload offsets (relative to start of payload, after flags byte)
 // Payload layout: 00 00 [seq] [data...]

--- a/esphome/components/grohe_sense_guard/grohe_protocol.h
+++ b/esphome/components/grohe_sense_guard/grohe_protocol.h
@@ -104,13 +104,15 @@ inline bool parse_frame(const std::vector<uint8_t> &buf, GroheFrame &frame) {
   return true;
 }
 
-// Build a config frame to send to MCU (valve open/close, snooze, sprinkler)
-// Based on flags=0x60 write packets observed in capture.
+// Build a frame to send to MCU.
+// data = complete payload including the leading 00 00 seq prefix.
+// L = CI_SUB + CI_APP + type + flags + data = 4 + data.size() + 1 = data.size() + 5
+// (empirically verified: STATUS 16-byte payload → L=21, CONFIG 85-byte → L=90)
 inline std::vector<uint8_t> build_frame(
     const uint8_t *addr,
     uint8_t msg_type,
     uint8_t flags,
-    uint8_t seq,
+    uint8_t /*seq*/,
     const std::vector<uint8_t> &data)
 {
   std::vector<uint8_t> frame;
@@ -118,24 +120,7 @@ inline std::vector<uint8_t> build_frame(
   // Wake preamble
   frame.insert(frame.end(), 4, GROHE_WAKE_BYTE);
 
-  // Compute inner data: ctrl + addr + CI_SUB + CI_APP + type + flags + 00 00 seq + data
-  std::vector<uint8_t> inner;
-  inner.push_back(GROHE_CTRL);
-  for (int i = 0; i < 6; i++) inner.push_back(addr[i]);
-  inner.push_back(GROHE_CI_SUB);
-  inner.push_back(GROHE_CI_APP);
-  inner.push_back(msg_type);
-  inner.push_back(flags);
-  inner.push_back(0x00);
-  inner.push_back(0x00);
-  inner.push_back(seq);
-  inner.insert(inner.end(), data.begin(), data.end());
-
-  uint8_t length = static_cast<uint8_t>(inner.size() - 1); // excl ctrl in some variants
-  // Length = number of bytes from CI_SUB to end of data (excl ctrl, addr, and 68 bytes)
-  // From observed packets: length = total payload + overhead - frame bytes
-  // Empirically: length = data.size() + 9 (CI_SUB + CI_APP + type + flags + 00 00 seq = 7 + correction)
-  length = static_cast<uint8_t>(data.size() + 7 + 3); // approximate; refine from captures
+  uint8_t length = static_cast<uint8_t>(data.size() + 5);
 
   frame.push_back(GROHE_START_BYTE);
   for (int i = 0; i < 6; i++) frame.push_back(addr[i]);
@@ -149,15 +134,12 @@ inline std::vector<uint8_t> build_frame(
   frame.push_back(GROHE_CI_APP);
   frame.push_back(msg_type);
   frame.push_back(flags);
-  frame.push_back(0x00);
-  frame.push_back(0x00);
-  frame.push_back(seq);
+  // data contains the complete payload (00 00 seq prefix is part of data, not added separately)
   frame.insert(frame.end(), data.begin(), data.end());
 
-  // Checksum: sum of bytes from second 0x68 (index 11) to last data byte, minus 2, mod 256.
-  // Verified empirically from captured frames: actual_cs = candidate_A - 2.
+  // CS = sum from second 0x68 (frame[11]) to last data byte, minus 2, mod 256.
   uint8_t cs = 0;
-  for (size_t i = 11; i < frame.size(); i++) cs += frame[i]; // second 0x68 is at index 11
+  for (size_t i = 11; i < frame.size(); i++) cs += frame[i];
   cs = static_cast<uint8_t>(cs - 2);
   frame.push_back(cs);
   frame.push_back(GROHE_STOP_BYTE);

--- a/esphome/components/grohe_sense_guard/grohe_protocol.h
+++ b/esphome/components/grohe_sense_guard/grohe_protocol.h
@@ -152,9 +152,11 @@ inline std::vector<uint8_t> build_frame(
   frame.push_back(seq);
   frame.insert(frame.end(), data.begin(), data.end());
 
-  // Checksum: sum of all bytes from second 68 to last data byte, mod 256
+  // Checksum: sum of bytes from second 0x68 (index 11) to last data byte, minus 2, mod 256.
+  // Verified empirically from captured frames: actual_cs = candidate_A - 2.
   uint8_t cs = 0;
-  for (size_t i = 4 + 1; i < frame.size(); i++) cs += frame[i]; // skip FE×4 + first 68
+  for (size_t i = 11; i < frame.size(); i++) cs += frame[i]; // second 0x68 is at index 11
+  cs = static_cast<uint8_t>(cs - 2);
   frame.push_back(cs);
   frame.push_back(GROHE_STOP_BYTE);
 

--- a/esphome/components/grohe_sense_guard/grohe_protocol.h
+++ b/esphome/components/grohe_sense_guard/grohe_protocol.h
@@ -1,0 +1,165 @@
+#pragma once
+#include <vector>
+#include <cstdint>
+
+namespace esphome {
+namespace grohe_sense_guard {
+
+// Frame constants
+static const uint8_t GROHE_WAKE_BYTE   = 0xFE;
+static const uint8_t GROHE_START_BYTE  = 0x68;
+static const uint8_t GROHE_START2_ACK  = 0x6A;
+static const uint8_t GROHE_STOP_BYTE   = 0x16;
+static const uint8_t GROHE_CI_SUB      = 0x0C;
+static const uint8_t GROHE_CI_APP      = 0x61;
+static const uint8_t GROHE_CTRL        = 0x1F;
+
+// Message types
+static const uint8_t MSG_INFO          = 0x01;
+static const uint8_t MSG_WATER_DATA    = 0x03;
+static const uint8_t MSG_CONFIG        = 0x04;
+static const uint8_t MSG_STATUS        = 0x05;
+static const uint8_t MSG_HEARTBEAT     = 0x06;
+static const uint8_t MSG_CONFIG_RESP   = 0x0C;
+
+// Flags
+static const uint8_t FLAG_READ         = 0x20;
+static const uint8_t FLAG_WRITE        = 0x60;
+
+// Payload offsets (relative to start of payload, after flags byte)
+// Payload layout: 00 00 [seq] [data...]
+static const uint8_t PAY_SEQ           = 2;  // sequence number
+
+// Status packet (MSG_STATUS) payload offsets
+static const uint8_t STATUS_PRESSURE_TEST = 3;  // 0x08 = pressure test running
+static const uint8_t STATUS_VALVE_STATE   = 7;  // 0x01 = open, 0x00 = closed
+static const uint8_t STATUS_SNOOZE        = 12; // 0x01 = active
+
+// Config packet (MSG_CONFIG) payload offsets
+static const uint8_t CFG_TIMESTAMP    = 11; // uint32 LE, Unix timestamp
+static const uint8_t CFG_FLOW_LIMIT   = 15; // uint16 LE, l/h * 10
+static const uint8_t CFG_PRESS_MAX    = 19; // uint16 LE, mbar
+static const uint8_t CFG_TIME_LIMIT   = 23; // uint16 LE, minutes
+static const uint8_t CFG_SPRINKLER_START = 73; // uint16 LE, minutes from midnight
+static const uint8_t CFG_SPRINKLER_STOP  = 75; // uint16 LE, minutes from midnight
+static const uint8_t CFG_SPRINKLER_MON  = 77;
+static const uint8_t CFG_SPRINKLER_TUE  = 78;
+static const uint8_t CFG_SPRINKLER_WED  = 79;
+static const uint8_t CFG_SPRINKLER_THU  = 80;
+static const uint8_t CFG_SPRINKLER_FRI  = 81;
+static const uint8_t CFG_SPRINKLER_SAT  = 82;
+static const uint8_t CFG_SPRINKLER_SUN  = 83;
+
+struct GroheFrame {
+  uint8_t  addr[6];
+  uint8_t  frame2;       // 0x68 or 0x6A
+  uint8_t  length;
+  uint8_t  msg_type;
+  uint8_t  flags;
+  uint8_t  seq;
+  std::vector<uint8_t> payload; // full payload incl. 00 00 seq prefix
+  bool     valid;
+};
+
+// Parse a complete frame from a byte buffer.
+// Returns true and fills frame on success.
+inline bool parse_frame(const std::vector<uint8_t> &buf, GroheFrame &frame) {
+  frame.valid = false;
+
+  // Find first 0x68
+  size_t pos = 0;
+  while (pos < buf.size() && buf[pos] != GROHE_START_BYTE) pos++;
+  if (pos + 14 >= buf.size()) return false;
+
+  // Addr (6 bytes)
+  for (int i = 0; i < 6; i++) frame.addr[i] = buf[pos + 1 + i];
+
+  // Second start byte
+  frame.frame2 = buf[pos + 7];
+  if (frame.frame2 != GROHE_START_BYTE && frame.frame2 != GROHE_START2_ACK)
+    return false;
+
+  // ctrl(1F), length, 00, 00, length2, CI_SUB(0C), CI_APP(61), type, flags
+  if (buf[pos + 8] != GROHE_CTRL) return false;
+  frame.length    = buf[pos + 9];
+  // buf[pos+10] buf[pos+11] = 00 00
+  // buf[pos+12] = length echo
+  if (buf[pos + 13] != GROHE_CI_SUB) return false;
+  if (buf[pos + 14] != GROHE_CI_APP) return false;
+
+  frame.msg_type = buf[pos + 15];
+  frame.flags    = buf[pos + 16];
+
+  // Payload starts at pos+17, ends before CS and stop byte
+  if (buf.back() != GROHE_STOP_BYTE) return false;
+  // CS = buf[buf.size()-2], stop = buf[buf.size()-1]
+  frame.payload.assign(buf.begin() + pos + 17, buf.end() - 2);
+
+  if (frame.payload.size() > PAY_SEQ)
+    frame.seq = frame.payload[PAY_SEQ];
+
+  frame.valid = true;
+  return true;
+}
+
+// Build a config frame to send to MCU (valve open/close, snooze, sprinkler)
+// Based on flags=0x60 write packets observed in capture.
+inline std::vector<uint8_t> build_frame(
+    const uint8_t *addr,
+    uint8_t msg_type,
+    uint8_t flags,
+    uint8_t seq,
+    const std::vector<uint8_t> &data)
+{
+  std::vector<uint8_t> frame;
+
+  // Wake preamble
+  frame.insert(frame.end(), 4, GROHE_WAKE_BYTE);
+
+  // Compute inner data: ctrl + addr + CI_SUB + CI_APP + type + flags + 00 00 seq + data
+  std::vector<uint8_t> inner;
+  inner.push_back(GROHE_CTRL);
+  for (int i = 0; i < 6; i++) inner.push_back(addr[i]);
+  inner.push_back(GROHE_CI_SUB);
+  inner.push_back(GROHE_CI_APP);
+  inner.push_back(msg_type);
+  inner.push_back(flags);
+  inner.push_back(0x00);
+  inner.push_back(0x00);
+  inner.push_back(seq);
+  inner.insert(inner.end(), data.begin(), data.end());
+
+  uint8_t length = static_cast<uint8_t>(inner.size() - 1); // excl ctrl in some variants
+  // Length = number of bytes from CI_SUB to end of data (excl ctrl, addr, and 68 bytes)
+  // From observed packets: length = total payload + overhead - frame bytes
+  // Empirically: length = data.size() + 9 (CI_SUB + CI_APP + type + flags + 00 00 seq = 7 + correction)
+  length = static_cast<uint8_t>(data.size() + 7 + 3); // approximate; refine from captures
+
+  frame.push_back(GROHE_START_BYTE);
+  for (int i = 0; i < 6; i++) frame.push_back(addr[i]);
+  frame.push_back(GROHE_START_BYTE);
+  frame.push_back(GROHE_CTRL);
+  frame.push_back(length);
+  frame.push_back(0x00);
+  frame.push_back(0x00);
+  frame.push_back(length);
+  frame.push_back(GROHE_CI_SUB);
+  frame.push_back(GROHE_CI_APP);
+  frame.push_back(msg_type);
+  frame.push_back(flags);
+  frame.push_back(0x00);
+  frame.push_back(0x00);
+  frame.push_back(seq);
+  frame.insert(frame.end(), data.begin(), data.end());
+
+  // Checksum: sum of all bytes from second 68 to last data byte, mod 256
+  uint8_t cs = 0;
+  for (size_t i = 4 + 1; i < frame.size(); i++) cs += frame[i]; // skip FE×4 + first 68
+  frame.push_back(cs);
+  frame.push_back(GROHE_STOP_BYTE);
+
+  return frame;
+}
+
+}  // namespace grohe_sense_guard
+}  // namespace esphome

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -187,10 +187,11 @@ void GroheSenseGuard::handle_config_(const GroheFrame &f) {
   // Cache config for later partial writes (e.g. only change sprinkler days)
   last_config_payload_ = p;
 
-  uint16_t start_min = (static_cast<uint16_t>(p[CFG_SPRINKLER_START + 1]) << 8)
-                      | p[CFG_SPRINKLER_START];
-  uint16_t stop_min  = (static_cast<uint16_t>(p[CFG_SPRINKLER_STOP + 1]) << 8)
-                      | p[CFG_SPRINKLER_STOP];
+  // Sprinkler times are stored big-endian (high byte first) in the CONFIG payload.
+  uint16_t start_min = (static_cast<uint16_t>(p[CFG_SPRINKLER_START]) << 8)
+                      | p[CFG_SPRINKLER_START + 1];
+  uint16_t stop_min  = (static_cast<uint16_t>(p[CFG_SPRINKLER_STOP]) << 8)
+                      | p[CFG_SPRINKLER_STOP + 1];
 
   ESP_LOGI(TAG, "Config: sprinkler %02u:%02u – %02u:%02u  days=",
            start_min / 60, start_min % 60,
@@ -288,10 +289,10 @@ void GroheSenseGuard::set_sprinkler(uint16_t start_min, uint16_t stop_min, bool 
   // Modify a copy of the last known config
   std::vector<uint8_t> payload = last_config_payload_;
   payload[PAY_SEQ] = next_seq_();
-  payload[CFG_SPRINKLER_START]     = start_min & 0xFF;
-  payload[CFG_SPRINKLER_START + 1] = start_min >> 8;
-  payload[CFG_SPRINKLER_STOP]      = stop_min & 0xFF;
-  payload[CFG_SPRINKLER_STOP + 1]  = stop_min >> 8;
+  payload[CFG_SPRINKLER_START]     = start_min >> 8;      // big-endian
+  payload[CFG_SPRINKLER_START + 1] = start_min & 0xFF;
+  payload[CFG_SPRINKLER_STOP]      = stop_min >> 8;
+  payload[CFG_SPRINKLER_STOP + 1]  = stop_min & 0xFF;
   for (int d = 0; d < 7; d++)
     payload[CFG_SPRINKLER_MON + d] = days[d] ? 0x01 : 0x00;
 

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -1,0 +1,290 @@
+#include "grohe_sense_guard.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace grohe_sense_guard {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Setup / Loop
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::setup() {
+  ESP_LOGI(TAG, "Grohe Sense Guard component ready");
+}
+
+void GroheSenseGuard::loop() {
+  const uint32_t now = millis();
+
+  // Flush incomplete frame if no byte received for 50 ms
+  if (in_frame_ && (now - last_byte_ms_ > 50)) {
+    ESP_LOGW(TAG, "Frame timeout, flushing %u bytes", (unsigned)rx_buf_.size());
+    rx_buf_.clear();
+    in_frame_ = false;
+  }
+
+  while (available()) {
+    uint8_t byte;
+    read_byte(&byte);
+    process_byte_(byte);
+    last_byte_ms_ = now;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Byte-level receive state machine
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::process_byte_(uint8_t byte) {
+  // Ignore wake bytes outside a frame
+  if (!in_frame_ && byte == GROHE_WAKE_BYTE) return;
+
+  if (!in_frame_) {
+    if (byte == GROHE_START_BYTE) {
+      rx_buf_.clear();
+      rx_buf_.push_back(byte);
+      in_frame_ = true;
+    }
+    return;
+  }
+
+  rx_buf_.push_back(byte);
+
+  // Minimum frame: 68 [6addr] 68 ctrl len 00 00 len 0C 61 type flags 00 00 seq CS 16
+  // = 1+6+1+1+1+2+1+1+1+1+1+1+1+2+1+1 = 22 bytes minimum
+  if (byte == GROHE_STOP_BYTE && rx_buf_.size() >= 22) {
+    process_frame_();
+    rx_buf_.clear();
+    in_frame_ = false;
+  }
+
+  // Safety: discard if buffer too large (max frame ~200 bytes)
+  if (rx_buf_.size() > 200) {
+    ESP_LOGW(TAG, "Frame buffer overflow, discarding");
+    rx_buf_.clear();
+    in_frame_ = false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Frame parser dispatcher
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::process_frame_() {
+  GroheFrame frame;
+  if (!parse_frame(rx_buf_, frame)) {
+    ESP_LOGD(TAG, "Failed to parse frame (%u bytes)", (unsigned)rx_buf_.size());
+    return;
+  }
+
+  // Remember device address for sending commands back
+  memcpy(dev_addr_, frame.addr, 6);
+
+  ESP_LOGD(TAG, "Frame: type=0x%02X flags=0x%02X seq=%u payload=%u bytes",
+           frame.msg_type, frame.flags, frame.seq, (unsigned)frame.payload.size());
+
+  switch (frame.msg_type) {
+    case MSG_INFO:      handle_info_(frame);    break;
+    case MSG_STATUS:    handle_status_(frame);  break;
+    case MSG_CONFIG:
+    case MSG_CONFIG_RESP: handle_config_(frame); break;
+    case MSG_HEARTBEAT:
+      ESP_LOGD(TAG, "Heartbeat seq=%u", frame.seq);
+      break;
+    case MSG_WATER_DATA:
+      ESP_LOGD(TAG, "Water data seq=%u", frame.seq);
+      break;
+    default:
+      ESP_LOGD(TAG, "Unknown type 0x%02X", frame.msg_type);
+      break;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Info packet (firmware version, device serial)
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::handle_info_(const GroheFrame &f) {
+  // ASCII identifier starts at payload[13] (after fixed header fields)
+  // "^1Z16010C186E000200040004" = firmware/serial string
+  if (firmware_version_ && f.payload.size() >= 14) {
+    std::string ver;
+    for (size_t i = 13; i < f.payload.size(); i++) {
+      uint8_t b = f.payload[i];
+      if (b == 0x00) break;
+      if (b >= 0x20 && b < 0x7F) ver += static_cast<char>(b);
+    }
+    if (!ver.empty()) {
+      ESP_LOGI(TAG, "Firmware/ID: %s", ver.c_str());
+      firmware_version_->publish_state(ver);
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Status packet (valve, snooze, pressure test)
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::handle_status_(const GroheFrame &f) {
+  const auto &p = f.payload;
+
+  if (p.size() <= STATUS_SNOOZE) {
+    ESP_LOGW(TAG, "Status packet too short: %u", (unsigned)p.size());
+    return;
+  }
+
+  bool ptest  = (p[STATUS_PRESSURE_TEST] == 0x08);
+  bool vopen  = (p[STATUS_VALVE_STATE]   == 0x01);
+  bool snooze = (p[STATUS_SNOOZE]        == 0x01);
+
+  ESP_LOGI(TAG, "Status: valve=%s snooze=%s pressure_test=%s",
+           vopen ? "OPEN" : "CLOSED",
+           snooze ? "ON" : "OFF",
+           ptest ? "RUNNING" : "idle");
+
+  if (valve_open_)    valve_open_->publish_state(vopen);
+  if (snooze_active_) snooze_active_->publish_state(snooze);
+  if (pressure_test_) pressure_test_->publish_state(ptest);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config packet (sprinkler times and days)
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::handle_config_(const GroheFrame &f) {
+  const auto &p = f.payload;
+
+  if (p.size() <= CFG_SPRINKLER_SUN) {
+    ESP_LOGW(TAG, "Config packet too short: %u", (unsigned)p.size());
+    return;
+  }
+
+  // Cache config for later partial writes (e.g. only change sprinkler days)
+  last_config_payload_ = p;
+
+  uint16_t start_min = (static_cast<uint16_t>(p[CFG_SPRINKLER_START + 1]) << 8)
+                      | p[CFG_SPRINKLER_START];
+  uint16_t stop_min  = (static_cast<uint16_t>(p[CFG_SPRINKLER_STOP + 1]) << 8)
+                      | p[CFG_SPRINKLER_STOP];
+
+  ESP_LOGI(TAG, "Config: sprinkler %02u:%02u – %02u:%02u  days=",
+           start_min / 60, start_min % 60,
+           stop_min  / 60, stop_min  % 60);
+
+  static const char *day_names[] = {"Mon","Tue","Wed","Thu","Fri","Sat","Sun"};
+  for (int d = 0; d < 7; d++) {
+    bool active = (p[CFG_SPRINKLER_MON + d] == 0x01);
+    ESP_LOGI(TAG, "  %s: %s", day_names[d], active ? "ON" : "off");
+    if (sprinkler_days_[d]) sprinkler_days_[d]->publish_state(active);
+  }
+
+  if (sprinkler_start_) sprinkler_start_->publish_state(start_min);
+  if (sprinkler_stop_)  sprinkler_stop_->publish_state(stop_min);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Valve open
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::valve_open() {
+  ESP_LOGI(TAG, "CMD: valve open");
+  // Status payload with valve=0x01
+  // Based on observed status packet structure: 00 00 [seq] 00 00 00 07 01 ...
+  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
+                                0x00, 0x00, 0x00, 0x07,
+                                0x01, // valve open
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Valve close
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::valve_close() {
+  ESP_LOGI(TAG, "CMD: valve close");
+  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
+                                0x00, 0x00, 0x00, 0x07,
+                                0x00, // valve closed
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Snooze start
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::snooze_start(uint16_t duration_minutes) {
+  ESP_LOGI(TAG, "CMD: snooze start %u min", duration_minutes);
+  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
+                                0x00, 0x00, 0x00, 0x07,
+                                0x00,
+                                0x00, 0x00, 0x00, 0x00,
+                                0x01, // snooze active
+                                static_cast<uint8_t>(duration_minutes & 0xFF),
+                                static_cast<uint8_t>(duration_minutes >> 8),
+                                0x02};
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Snooze stop
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::snooze_stop() {
+  ESP_LOGI(TAG, "CMD: snooze stop");
+  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
+                                0x00, 0x00, 0x00, 0x07,
+                                0x00,
+                                0x00, 0x00, 0x00, 0x00,
+                                0x00, // snooze off
+                                0x00, 0x00, 0x02};
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Sprinkler configure
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::set_sprinkler(uint16_t start_min, uint16_t stop_min, bool days[7]) {
+  if (last_config_payload_.empty()) {
+    ESP_LOGW(TAG, "No config cached yet – wait for first config packet");
+    return;
+  }
+
+  // Modify a copy of the last known config
+  std::vector<uint8_t> payload = last_config_payload_;
+  payload[PAY_SEQ] = next_seq_();
+  payload[CFG_SPRINKLER_START]     = start_min & 0xFF;
+  payload[CFG_SPRINKLER_START + 1] = start_min >> 8;
+  payload[CFG_SPRINKLER_STOP]      = stop_min & 0xFF;
+  payload[CFG_SPRINKLER_STOP + 1]  = stop_min >> 8;
+  for (int d = 0; d < 7; d++)
+    payload[CFG_SPRINKLER_MON + d] = days[d] ? 0x01 : 0x00;
+
+  ESP_LOGI(TAG, "CMD: sprinkler %02u:%02u – %02u:%02u",
+           start_min / 60, start_min % 60,
+           stop_min  / 60, stop_min  % 60);
+
+  send_frame_(build_frame(dev_addr_, MSG_CONFIG, FLAG_WRITE, payload[PAY_SEQ], payload));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Sprinkler off (all days disabled)
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::sprinkler_off() {
+  bool days[7] = {false, false, false, false, false, false, false};
+  set_sprinkler(0, 0, days);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Send a raw frame via UART
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::send_frame_(const std::vector<uint8_t> &frame) {
+  ESP_LOGD(TAG, "TX %u bytes", (unsigned)frame.size());
+  for (uint8_t b : frame) write_byte(b);
+}
+
+}  // namespace grohe_sense_guard
+}  // namespace esphome

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -219,8 +219,12 @@ bool GroheSenseGuard::build_status_cmd_(std::vector<uint8_t> &payload,
                                          int snooze,  // -1=keep, 0=off, 1=on
                                          uint16_t snooze_min) {
   if (last_status_payload_.size() <= STATUS_SNOOZE) {
-    ESP_LOGW(TAG, "No STATUS cached yet – wait for first status packet");
-    return false;
+    // No STATUS received yet — use safe default matching observed app format.
+    // 16 bytes: 00 00 [seq] 00 00 00 07 [valve=0] 00 00 00 00 [snooze=0] 00 00 02
+    ESP_LOGD(TAG, "No STATUS cached, using default template");
+    last_status_payload_.assign(16, 0x00);
+    last_status_payload_[6]  = 0x07;
+    last_status_payload_[15] = 0x02;
   }
   payload = last_status_payload_;
   payload[PAY_SEQ] = next_seq_();

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -84,6 +84,7 @@ void GroheSenseGuard::process_frame_() {
 
   // Publish to raw sensors + fire callbacks for every frame
   publish_raw_frame_(frame, rx_buf_);
+  verify_checksum_(rx_buf_);
 
   switch (frame.msg_type) {
     case MSG_INFO:      handle_info_(frame);    break;
@@ -94,7 +95,7 @@ void GroheSenseGuard::process_frame_() {
       ESP_LOGD(TAG, "Heartbeat seq=%u", frame.seq);
       break;
     case MSG_WATER_DATA:
-      ESP_LOGD(TAG, "Water data seq=%u", frame.seq);
+      handle_water_data_(frame);
       break;
     default:
       ESP_LOGW(TAG, "UNKNOWN type=0x%02X flags=0x%02X seq=%u payload: %s",
@@ -131,6 +132,18 @@ void GroheSenseGuard::handle_info_(const GroheFrame &f) {
 // Status packet (valve, snooze, pressure test)
 // ─────────────────────────────────────────────────────────────────────────────
 
+void GroheSenseGuard::handle_water_data_(const GroheFrame &f) {
+  // Short counter/poll frames (type 0x03). Payload: 00 00 00 00 00 00 01 00 [counter]
+  // The last byte increments each transmission; CS tracks it linearly.
+  const auto &p = f.payload;
+  if (!p.empty()) {
+    ESP_LOGD(TAG, "WaterData: counter=0x%02X payload=%s",
+             p.back(), to_hex_(p).c_str());
+  } else {
+    ESP_LOGD(TAG, "WaterData: empty payload");
+  }
+}
+
 void GroheSenseGuard::handle_status_(const GroheFrame &f) {
   const auto &p = f.payload;
 
@@ -141,12 +154,15 @@ void GroheSenseGuard::handle_status_(const GroheFrame &f) {
 
   bool ptest  = (p[STATUS_PRESSURE_TEST] == 0x08);
   bool vopen  = (p[STATUS_VALVE_STATE]   == 0x01);
-  bool snooze = (p[STATUS_SNOOZE]        == 0x01);
+  // Snooze is encoded in both flags bit 1 (0x02) and payload[STATUS_SNOOZE].
+  // Use flags as primary since it appears in every status frame.
+  bool snooze = (f.flags & 0x02) || (p[STATUS_SNOOZE] == 0x01);
 
-  ESP_LOGI(TAG, "Status: valve=%s snooze=%s pressure_test=%s",
+  ESP_LOGI(TAG, "Status: valve=%s snooze=%s pressure_test=%s flags=0x%02X",
            vopen ? "OPEN" : "CLOSED",
            snooze ? "ON" : "OFF",
-           ptest ? "RUNNING" : "idle");
+           ptest ? "RUNNING" : "idle",
+           f.flags);
 
   if (valve_open_)    valve_open_->publish_state(vopen);
   if (snooze_active_) snooze_active_->publish_state(snooze);
@@ -253,8 +269,9 @@ void GroheSenseGuard::snooze_stop() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 void GroheSenseGuard::set_sprinkler(uint16_t start_min, uint16_t stop_min, bool days[7]) {
-  if (last_config_payload_.empty()) {
-    ESP_LOGW(TAG, "No config cached yet – wait for first config packet");
+  if (last_config_payload_.size() <= CFG_SPRINKLER_SUN) {
+    ESP_LOGW(TAG, "Config not received yet (size=%u, need>%u) – trigger a config read first",
+             (unsigned)last_config_payload_.size(), (unsigned)CFG_SPRINKLER_SUN);
     return;
   }
 
@@ -321,8 +338,40 @@ void GroheSenseGuard::publish_raw_frame_(const GroheFrame &f,
     cb(f.msg_type, f.flags, to_hex_(raw));
 }
 
+void GroheSenseGuard::verify_checksum_(const std::vector<uint8_t> &raw) {
+  // raw ends with [CS] [0x16]. Compute CS candidates so we can identify the correct algorithm.
+  if (raw.size() < 4) return;
+  uint8_t actual_cs = raw[raw.size() - 2];
+
+  // Find position of first 0x68
+  size_t pos = 0;
+  while (pos < raw.size() && raw[pos] != 0x68) pos++;
+  if (pos >= raw.size()) return;
+
+  // Candidate A: sum from second 68 (pos+7) to last data byte (raw.size()-3), mod 256
+  uint8_t cs_a = 0;
+  for (size_t i = pos + 7; i < raw.size() - 2; i++) cs_a += raw[i];
+
+  // Candidate B: sum from ctrl byte (pos+8) to last data byte, mod 256
+  uint8_t cs_b = 0;
+  for (size_t i = pos + 8; i < raw.size() - 2; i++) cs_b += raw[i];
+
+  // Candidate C: sum from addr start (pos+1) to last data byte, mod 256
+  uint8_t cs_c = 0;
+  for (size_t i = pos + 1; i < raw.size() - 2; i++) cs_c += raw[i];
+
+  // Candidate D: sum from CI_SUB (pos+13) to last data byte, mod 256
+  uint8_t cs_d = 0;
+  if (pos + 13 < raw.size() - 2)
+    for (size_t i = pos + 13; i < raw.size() - 2; i++) cs_d += raw[i];
+
+  ESP_LOGD(TAG, "CS actual=0x%02X | A(from2nd68)=0x%02X B(fromCtrl)=0x%02X C(fromAddr)=0x%02X D(fromCI)=0x%02X",
+           actual_cs, cs_a, cs_b, cs_c, cs_d);
+}
+
 void GroheSenseGuard::send_frame_(const std::vector<uint8_t> &frame) {
-  ESP_LOGD(TAG, "TX %u bytes", (unsigned)frame.size());
+  uint8_t cs = frame.size() >= 2 ? frame[frame.size() - 2] : 0;
+  ESP_LOGD(TAG, "TX %u bytes CS=0x%02X", (unsigned)frame.size(), cs);
   for (uint8_t b : frame) write_byte(b);
 }
 

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -247,6 +247,7 @@ bool GroheSenseGuard::build_status_cmd_(std::vector<uint8_t> &payload,
     ESP_LOGD(TAG, "No STATUS cached, using default template");
     last_status_payload_.assign(16, 0x00);
     last_status_payload_[6]  = 0x07;
+    last_status_payload_[12] = 0x01; // app always sets this byte; required for MCU to execute
     last_status_payload_[15] = 0x02;
   }
   payload = last_status_payload_;

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -12,6 +12,14 @@ void GroheSenseGuard::setup() {
   ESP_LOGI(TAG, "Grohe Sense Guard component ready");
 }
 
+void GroheSenseGuard::update() {
+  // Send a type=0x03 poll frame so the MCU sends back STATUS + CONFIG.
+  // The MCU sends these counter frames periodically itself; we mirror the format.
+  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, poll_counter_++};
+  send_frame_(build_frame(dev_addr_, MSG_WATER_DATA, FLAG_READ, 0, data));
+  ESP_LOGD(TAG, "Poll: counter=0x%02X", poll_counter_ - 1);
+}
+
 void GroheSenseGuard::loop() {
   const uint32_t now = millis();
 

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -82,6 +82,9 @@ void GroheSenseGuard::process_frame_() {
   ESP_LOGD(TAG, "Frame: type=0x%02X flags=0x%02X seq=%u payload=%u bytes",
            frame.msg_type, frame.flags, frame.seq, (unsigned)frame.payload.size());
 
+  // Publish to raw sensors + fire callbacks for every frame
+  publish_raw_frame_(frame, rx_buf_);
+
   switch (frame.msg_type) {
     case MSG_INFO:      handle_info_(frame);    break;
     case MSG_STATUS:    handle_status_(frame);  break;
@@ -94,7 +97,11 @@ void GroheSenseGuard::process_frame_() {
       ESP_LOGD(TAG, "Water data seq=%u", frame.seq);
       break;
     default:
-      ESP_LOGD(TAG, "Unknown type 0x%02X", frame.msg_type);
+      ESP_LOGW(TAG, "UNKNOWN type=0x%02X flags=0x%02X seq=%u payload: %s",
+               frame.msg_type, frame.flags, frame.seq,
+               to_hex_(frame.payload).c_str());
+      if (last_unknown_frame_)
+        last_unknown_frame_->publish_state(to_hex_(rx_buf_));
       break;
   }
 }
@@ -280,6 +287,39 @@ void GroheSenseGuard::sprinkler_off() {
 // ─────────────────────────────────────────────────────────────────────────────
 // Send a raw frame via UART
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hex helper + raw frame publisher
+// ─────────────────────────────────────────────────────────────────────────────
+
+std::string GroheSenseGuard::to_hex_(const std::vector<uint8_t> &data) {
+  std::string out;
+  out.reserve(data.size() * 3);
+  char buf[4];
+  for (size_t i = 0; i < data.size(); i++) {
+    snprintf(buf, sizeof(buf), i ? " %02X" : "%02X", data[i]);
+    out += buf;
+  }
+  return out;
+}
+
+void GroheSenseGuard::publish_raw_frame_(const GroheFrame &f,
+                                          const std::vector<uint8_t> &raw) {
+  // Format: "type=0x04 flags=0x20 seq=11 | FE FE FE FE 68 ..."
+  char header[48];
+  snprintf(header, sizeof(header), "type=0x%02X flags=0x%02X seq=%u | ",
+           f.msg_type, f.flags, f.seq);
+  std::string full = std::string(header) + to_hex_(raw);
+
+  ESP_LOGV(TAG, "RAW: %s", full.c_str());
+
+  if (last_raw_frame_)
+    last_raw_frame_->publish_state(full);
+
+  // Fire registered callbacks
+  for (auto &cb : on_frame_callbacks_)
+    cb(f.msg_type, f.flags, to_hex_(raw));
+}
 
 void GroheSenseGuard::send_frame_(const std::vector<uint8_t> &frame) {
   ESP_LOGD(TAG, "TX %u bytes", (unsigned)frame.size());

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -224,6 +224,10 @@ bool GroheSenseGuard::build_status_cmd_(std::vector<uint8_t> &payload,
   }
   payload = last_status_payload_;
   payload[PAY_SEQ] = next_seq_();
+  // App write commands always use payload[5]=0x00, payload[6]=0x07.
+  // The MCU uses [5]=0x01, [6]=0x00 in broadcasts — override for commands.
+  payload[5] = 0x00;
+  payload[6] = 0x07;
   if (valve  >= 0) payload[STATUS_VALVE_STATE] = valve  ? 0x01 : 0x00;
   if (snooze >= 0) {
     payload[STATUS_SNOOZE] = snooze ? 0x01 : 0x00;
@@ -289,6 +293,8 @@ void GroheSenseGuard::set_sprinkler(uint16_t start_min, uint16_t stop_min, bool 
   // Modify a copy of the last known config
   std::vector<uint8_t> payload = last_config_payload_;
   payload[PAY_SEQ] = next_seq_();
+  payload[5] = 0x00;
+  payload[6] = 0x07; // app write commands always set this byte
   payload[CFG_SPRINKLER_START]     = start_min >> 8;      // big-endian
   payload[CFG_SPRINKLER_START + 1] = start_min & 0xFF;
   payload[CFG_SPRINKLER_STOP]      = stop_min >> 8;

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -147,6 +147,12 @@ void GroheSenseGuard::handle_water_data_(const GroheFrame &f) {
 void GroheSenseGuard::handle_status_(const GroheFrame &f) {
   const auto &p = f.payload;
 
+  // flags bit 0 (0x01) = short ACK frame (7 bytes), sent by MCU to confirm receipt of a command.
+  if (f.flags & 0x01) {
+    ESP_LOGD(TAG, "ACK: seq=%u flags=0x%02X", f.seq, f.flags);
+    return;
+  }
+
   if (p.size() <= STATUS_SNOOZE) {
     ESP_LOGW(TAG, "Status packet too short: %u", (unsigned)p.size());
     return;
@@ -281,6 +287,19 @@ void GroheSenseGuard::snooze_stop() {
   std::vector<uint8_t> data;
   if (!build_status_cmd_(data, -1, 0)) return;
   send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[PAY_SEQ], data));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Command: Request current status/config from MCU
+// ─────────────────────────────────────────────────────────────────────────────
+
+void GroheSenseGuard::request_status() {
+  ESP_LOGI(TAG, "CMD: request status");
+  // Short poll frame matching observed type=0x03 counter frames.
+  // Payload: 00 00 00 00 00 00 01 00 [counter]
+  uint8_t counter = next_seq_();
+  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, counter};
+  send_frame_(build_frame(dev_addr_, MSG_WATER_DATA, FLAG_READ, counter, data));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -13,11 +13,18 @@ void GroheSenseGuard::setup() {
 }
 
 void GroheSenseGuard::update() {
-  // Send a type=0x03 poll frame so the MCU sends back STATUS + CONFIG.
-  // The MCU sends these counter frames periodically itself; we mirror the format.
-  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, poll_counter_++};
-  send_frame_(build_frame(dev_addr_, MSG_WATER_DATA, FLAG_READ, 0, data));
-  ESP_LOGD(TAG, "Poll: counter=0x%02X", poll_counter_ - 1);
+  // Send a STATUS read request (type=0x05, flags=0x20, minimal payload).
+  // This mirrors how the app polls current device state.
+  request_status();
+}
+
+void GroheSenseGuard::request_status() {
+  ESP_LOGI(TAG, "CMD: request status");
+  // Try STATUS read: minimal payload 00 00 seq 00 00 00 00 → ask MCU for current state
+  uint8_t seq = next_seq_();
+  std::vector<uint8_t> data(7, 0x00);
+  data[2] = seq;
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_READ, seq, data));
 }
 
 void GroheSenseGuard::loop() {
@@ -295,19 +302,6 @@ void GroheSenseGuard::snooze_stop() {
   std::vector<uint8_t> data;
   if (!build_status_cmd_(data, -1, 0)) return;
   send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[PAY_SEQ], data));
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Command: Request current status/config from MCU
-// ─────────────────────────────────────────────────────────────────────────────
-
-void GroheSenseGuard::request_status() {
-  ESP_LOGI(TAG, "CMD: request status");
-  // Short poll frame matching observed type=0x03 counter frames.
-  // Payload: 00 00 00 00 00 00 01 00 [counter]
-  uint8_t counter = next_seq_();
-  std::vector<uint8_t> data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, counter};
-  send_frame_(build_frame(dev_addr_, MSG_WATER_DATA, FLAG_READ, counter, data));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -152,6 +152,9 @@ void GroheSenseGuard::handle_status_(const GroheFrame &f) {
     return;
   }
 
+  // Cache for use as write template (mirrors CONFIG cache pattern)
+  last_status_payload_ = p;
+
   bool ptest  = (p[STATUS_PRESSURE_TEST] == 0x08);
   bool vopen  = (p[STATUS_VALVE_STATE]   == 0x01);
   // Snooze is encoded in both flags bit 1 (0x02) and payload[STATUS_SNOOZE].
@@ -208,15 +211,34 @@ void GroheSenseGuard::handle_config_(const GroheFrame &f) {
 // Command: Valve open
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Build a write-STATUS payload from the last received STATUS, changing only
+// the requested fields. Returns false if no STATUS has been cached yet.
+bool GroheSenseGuard::build_status_cmd_(std::vector<uint8_t> &payload,
+                                         int valve,   // -1=keep, 0=close, 1=open
+                                         int snooze,  // -1=keep, 0=off, 1=on
+                                         uint16_t snooze_min) {
+  if (last_status_payload_.size() <= STATUS_SNOOZE) {
+    ESP_LOGW(TAG, "No STATUS cached yet – wait for first status packet");
+    return false;
+  }
+  payload = last_status_payload_;
+  payload[PAY_SEQ] = next_seq_();
+  if (valve  >= 0) payload[STATUS_VALVE_STATE] = valve  ? 0x01 : 0x00;
+  if (snooze >= 0) {
+    payload[STATUS_SNOOZE] = snooze ? 0x01 : 0x00;
+    if (snooze && last_status_payload_.size() > STATUS_SNOOZE + 2) {
+      payload[STATUS_SNOOZE + 1] = static_cast<uint8_t>(snooze_min & 0xFF);
+      payload[STATUS_SNOOZE + 2] = static_cast<uint8_t>(snooze_min >> 8);
+    }
+  }
+  return true;
+}
+
 void GroheSenseGuard::valve_open() {
   ESP_LOGI(TAG, "CMD: valve open");
-  // Status payload with valve=0x01
-  // Based on observed status packet structure: 00 00 [seq] 00 00 00 07 01 ...
-  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
-                                0x00, 0x00, 0x00, 0x07,
-                                0x01, // valve open
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
-  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+  std::vector<uint8_t> data;
+  if (!build_status_cmd_(data, 1, -1)) return;
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[PAY_SEQ], data));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -225,11 +247,9 @@ void GroheSenseGuard::valve_open() {
 
 void GroheSenseGuard::valve_close() {
   ESP_LOGI(TAG, "CMD: valve close");
-  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
-                                0x00, 0x00, 0x00, 0x07,
-                                0x00, // valve closed
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02};
-  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+  std::vector<uint8_t> data;
+  if (!build_status_cmd_(data, 0, -1)) return;
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[PAY_SEQ], data));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -238,15 +258,9 @@ void GroheSenseGuard::valve_close() {
 
 void GroheSenseGuard::snooze_start(uint16_t duration_minutes) {
   ESP_LOGI(TAG, "CMD: snooze start %u min", duration_minutes);
-  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
-                                0x00, 0x00, 0x00, 0x07,
-                                0x00,
-                                0x00, 0x00, 0x00, 0x00,
-                                0x01, // snooze active
-                                static_cast<uint8_t>(duration_minutes & 0xFF),
-                                static_cast<uint8_t>(duration_minutes >> 8),
-                                0x02};
-  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+  std::vector<uint8_t> data;
+  if (!build_status_cmd_(data, -1, 1, duration_minutes)) return;
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[PAY_SEQ], data));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -255,13 +269,9 @@ void GroheSenseGuard::snooze_start(uint16_t duration_minutes) {
 
 void GroheSenseGuard::snooze_stop() {
   ESP_LOGI(TAG, "CMD: snooze stop");
-  std::vector<uint8_t> data = {0x00, 0x00, next_seq_(),
-                                0x00, 0x00, 0x00, 0x07,
-                                0x00,
-                                0x00, 0x00, 0x00, 0x00,
-                                0x00, // snooze off
-                                0x00, 0x00, 0x02};
-  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[2], data));
+  std::vector<uint8_t> data;
+  if (!build_status_cmd_(data, -1, 0)) return;
+  send_frame_(build_frame(dev_addr_, MSG_STATUS, FLAG_WRITE, data[PAY_SEQ], data));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -13,14 +13,14 @@ void GroheSenseGuard::setup() {
 }
 
 void GroheSenseGuard::update() {
-  // Send a STATUS read request (type=0x05, flags=0x20, minimal payload).
-  // This mirrors how the app polls current device state.
-  request_status();
+  // Periodic keep-alive: only log that we are alive; the MCU drives heartbeat timing.
+  // Real polling happens in handle_water_data_ (we echo back MCU type=0x03 frames).
+  ESP_LOGD(TAG, "Alive (waiting for MCU heartbeat)");
 }
 
 void GroheSenseGuard::request_status() {
   ESP_LOGI(TAG, "CMD: request status");
-  // Try STATUS read: minimal payload 00 00 seq 00 00 00 00 → ask MCU for current state
+  // Send a minimal STATUS read request to ask MCU for current state.
   uint8_t seq = next_seq_();
   std::vector<uint8_t> data(7, 0x00);
   data[2] = seq;
@@ -148,15 +148,17 @@ void GroheSenseGuard::handle_info_(const GroheFrame &f) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 void GroheSenseGuard::handle_water_data_(const GroheFrame &f) {
-  // Short counter/poll frames (type 0x03). Payload: 00 00 00 00 00 00 01 00 [counter]
-  // The last byte increments each transmission; CS tracks it linearly.
+  // Periodic MCU heartbeat (type=0x03). Counter byte increments each frame.
+  // The ESP8266 likely responds to these to keep the session alive.
+  // We mirror the same frame back so the MCU sees an active controller.
   const auto &p = f.payload;
-  if (!p.empty()) {
-    ESP_LOGD(TAG, "WaterData: counter=0x%02X payload=%s",
-             p.back(), to_hex_(p).c_str());
-  } else {
-    ESP_LOGD(TAG, "WaterData: empty payload");
-  }
+  uint8_t counter = p.empty() ? 0x01 : p.back();
+  ESP_LOGD(TAG, "WaterData heartbeat counter=0x%02X – echoing back", counter);
+
+  // Echo: same payload format the MCU sent, counter unchanged
+  std::vector<uint8_t> reply(p.size(), 0x00);
+  if (!reply.empty()) reply.back() = counter;
+  send_frame_(build_frame(dev_addr_, MSG_WATER_DATA, FLAG_READ, 0, reply));
 }
 
 void GroheSenseGuard::handle_status_(const GroheFrame &f) {

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.cpp
@@ -365,8 +365,13 @@ void GroheSenseGuard::verify_checksum_(const std::vector<uint8_t> &raw) {
   if (pos + 13 < raw.size() - 2)
     for (size_t i = pos + 13; i < raw.size() - 2; i++) cs_d += raw[i];
 
-  ESP_LOGD(TAG, "CS actual=0x%02X | A(from2nd68)=0x%02X B(fromCtrl)=0x%02X C(fromAddr)=0x%02X D(fromCI)=0x%02X",
-           actual_cs, cs_a, cs_b, cs_c, cs_d);
+  bool ok = (static_cast<uint8_t>(cs_a - 2) == actual_cs);
+  if (ok) {
+    ESP_LOGV(TAG, "CS 0x%02X OK", actual_cs);
+  } else {
+    ESP_LOGW(TAG, "CS MISMATCH actual=0x%02X A-2=0x%02X A=0x%02X B=0x%02X C=0x%02X D=0x%02X",
+             actual_cs, (uint8_t)(cs_a - 2), cs_a, cs_b, cs_c, cs_d);
+  }
 }
 
 void GroheSenseGuard::send_frame_(const std::vector<uint8_t> &frame) {

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.h
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.h
@@ -56,6 +56,7 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   void snooze_stop();
   void set_sprinkler(uint16_t start_min, uint16_t stop_min, bool days[7]);
   void sprinkler_off();
+  void request_status();
 
  protected:
   // ── Receive buffer ───────────────────────────────────────────────────────

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.h
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.h
@@ -14,7 +14,7 @@ namespace grohe_sense_guard {
 
 static const char *const TAG = "grohe";
 
-class GroheSenseGuard : public Component, public uart::UARTDevice {
+class GroheSenseGuard : public PollingComponent, public uart::UARTDevice {
  public:
   // ── Sensor setters (called from sensor.py / binary_sensor.py) ────────────
   void set_valve_open(binary_sensor::BinarySensor *s)   { valve_open_ = s; }
@@ -48,6 +48,7 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   void setup() override;
   void loop() override;
   float get_setup_priority() const override { return setup_priority::DATA; }
+  void update() override;
 
   // ── Command API ──────────────────────────────────────────────────────────
   void valve_open();
@@ -66,7 +67,8 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
 
   // ── Last known device address ────────────────────────────────────────────
   uint8_t dev_addr_[6]{0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
-  uint8_t tx_seq_{0x20}; // outgoing sequence counter
+  uint8_t tx_seq_{0x01}; // outgoing sequence counter (start at 1, matching observed app frames)
+  uint8_t poll_counter_{0x01}; // type=0x03 counter byte, mirrors MCU behaviour
 
   // ── Last known config/status payloads (used for partial writes) ─────────
   std::vector<uint8_t> last_config_payload_;

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.h
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "grohe_protocol.h"
+#include <vector>
+
+namespace esphome {
+namespace grohe_sense_guard {
+
+static const char *const TAG = "grohe";
+
+class GroheSenseGuard : public Component, public uart::UARTDevice {
+ public:
+  // ── Sensor setters (called from sensor.py / binary_sensor.py) ────────────
+  void set_valve_open(binary_sensor::BinarySensor *s)   { valve_open_ = s; }
+  void set_snooze_active(binary_sensor::BinarySensor *s) { snooze_active_ = s; }
+  void set_pressure_test(binary_sensor::BinarySensor *s) { pressure_test_ = s; }
+
+  void set_sprinkler_monday(binary_sensor::BinarySensor *s)    { sprinkler_days_[0] = s; }
+  void set_sprinkler_tuesday(binary_sensor::BinarySensor *s)   { sprinkler_days_[1] = s; }
+  void set_sprinkler_wednesday(binary_sensor::BinarySensor *s) { sprinkler_days_[2] = s; }
+  void set_sprinkler_thursday(binary_sensor::BinarySensor *s)  { sprinkler_days_[3] = s; }
+  void set_sprinkler_friday(binary_sensor::BinarySensor *s)    { sprinkler_days_[4] = s; }
+  void set_sprinkler_saturday(binary_sensor::BinarySensor *s)  { sprinkler_days_[5] = s; }
+  void set_sprinkler_sunday(binary_sensor::BinarySensor *s)    { sprinkler_days_[6] = s; }
+
+  void set_sprinkler_start(sensor::Sensor *s) { sprinkler_start_ = s; }
+  void set_sprinkler_stop(sensor::Sensor *s)  { sprinkler_stop_ = s; }
+  void set_firmware_version(text_sensor::TextSensor *s) { firmware_version_ = s; }
+
+  // ── ESPHome lifecycle ────────────────────────────────────────────────────
+  void setup() override;
+  void loop() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  // ── Command API ──────────────────────────────────────────────────────────
+  void valve_open();
+  void valve_close();
+  void snooze_start(uint16_t duration_minutes);
+  void snooze_stop();
+  void set_sprinkler(uint16_t start_min, uint16_t stop_min, bool days[7]);
+  void sprinkler_off();
+
+ protected:
+  // ── Receive buffer ───────────────────────────────────────────────────────
+  std::vector<uint8_t> rx_buf_;
+  bool in_frame_{false};
+  uint32_t last_byte_ms_{0};
+
+  // ── Last known device address ────────────────────────────────────────────
+  uint8_t dev_addr_[6]{0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
+  uint8_t tx_seq_{0x20}; // outgoing sequence counter
+
+  // ── Last known config payload (used for partial writes) ─────────────────
+  std::vector<uint8_t> last_config_payload_;
+
+  // ── Sensors ─────────────────────────────────────────────────────────────
+  binary_sensor::BinarySensor *valve_open_{nullptr};
+  binary_sensor::BinarySensor *snooze_active_{nullptr};
+  binary_sensor::BinarySensor *pressure_test_{nullptr};
+  binary_sensor::BinarySensor *sprinkler_days_[7]{};
+  sensor::Sensor *sprinkler_start_{nullptr};
+  sensor::Sensor *sprinkler_stop_{nullptr};
+  text_sensor::TextSensor *firmware_version_{nullptr};
+
+  // ── Internal helpers ─────────────────────────────────────────────────────
+  void process_byte_(uint8_t byte);
+  void process_frame_();
+  void handle_info_(const GroheFrame &f);
+  void handle_status_(const GroheFrame &f);
+  void handle_config_(const GroheFrame &f);
+  void send_frame_(const std::vector<uint8_t> &frame);
+  uint8_t next_seq_() { return tx_seq_++; }
+};
+
+}  // namespace grohe_sense_guard
+}  // namespace esphome

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.h
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.h
@@ -87,9 +87,11 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   void process_byte_(uint8_t byte);
   void process_frame_();
   void handle_info_(const GroheFrame &f);
+  void handle_water_data_(const GroheFrame &f);
   void handle_status_(const GroheFrame &f);
   void handle_config_(const GroheFrame &f);
   void send_frame_(const std::vector<uint8_t> &frame);
+  void verify_checksum_(const std::vector<uint8_t> &raw);
   uint8_t next_seq_() { return tx_seq_++; }
 
   // Convert a byte vector to a hex string like "FE FE 68 ..."

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.h
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.h
@@ -67,8 +67,9 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   uint8_t dev_addr_[6]{0x99, 0x99, 0x99, 0x99, 0x99, 0x99};
   uint8_t tx_seq_{0x20}; // outgoing sequence counter
 
-  // ── Last known config payload (used for partial writes) ─────────────────
+  // ── Last known config/status payloads (used for partial writes) ─────────
   std::vector<uint8_t> last_config_payload_;
+  std::vector<uint8_t> last_status_payload_;
 
   // ── Sensors ─────────────────────────────────────────────────────────────
   binary_sensor::BinarySensor *valve_open_{nullptr};
@@ -90,6 +91,8 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   void handle_water_data_(const GroheFrame &f);
   void handle_status_(const GroheFrame &f);
   void handle_config_(const GroheFrame &f);
+  bool build_status_cmd_(std::vector<uint8_t> &payload, int valve, int snooze,
+                          uint16_t snooze_min = 0);
   void send_frame_(const std::vector<uint8_t> &frame);
   void verify_checksum_(const std::vector<uint8_t> &raw);
   uint8_t next_seq_() { return tx_seq_++; }

--- a/esphome/components/grohe_sense_guard/grohe_sense_guard.h
+++ b/esphome/components/grohe_sense_guard/grohe_sense_guard.h
@@ -33,6 +33,17 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   void set_sprinkler_stop(sensor::Sensor *s)  { sprinkler_stop_ = s; }
   void set_firmware_version(text_sensor::TextSensor *s) { firmware_version_ = s; }
 
+  // Raw frame capture – every received frame as hex string
+  void set_last_raw_frame(text_sensor::TextSensor *s)     { last_raw_frame_ = s; }
+  // Unknown frame types only
+  void set_last_unknown_frame(text_sensor::TextSensor *s) { last_unknown_frame_ = s; }
+
+  // Callback: fires for every successfully parsed frame (type, flags, hex payload)
+  // Register from YAML via on_frame automation trigger (future).
+  void add_on_frame_callback(std::function<void(uint8_t, uint8_t, std::string)> cb) {
+    on_frame_callbacks_.push_back(std::move(cb));
+  }
+
   // ── ESPHome lifecycle ────────────────────────────────────────────────────
   void setup() override;
   void loop() override;
@@ -67,6 +78,10 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   sensor::Sensor *sprinkler_start_{nullptr};
   sensor::Sensor *sprinkler_stop_{nullptr};
   text_sensor::TextSensor *firmware_version_{nullptr};
+  text_sensor::TextSensor *last_raw_frame_{nullptr};
+  text_sensor::TextSensor *last_unknown_frame_{nullptr};
+
+  std::vector<std::function<void(uint8_t, uint8_t, std::string)>> on_frame_callbacks_;
 
   // ── Internal helpers ─────────────────────────────────────────────────────
   void process_byte_(uint8_t byte);
@@ -76,6 +91,11 @@ class GroheSenseGuard : public Component, public uart::UARTDevice {
   void handle_config_(const GroheFrame &f);
   void send_frame_(const std::vector<uint8_t> &frame);
   uint8_t next_seq_() { return tx_seq_++; }
+
+  // Convert a byte vector to a hex string like "FE FE 68 ..."
+  static std::string to_hex_(const std::vector<uint8_t> &data);
+  // Publish frame to raw sensors and fire callbacks
+  void publish_raw_frame_(const GroheFrame &f, const std::vector<uint8_t> &raw);
 };
 
 }  // namespace grohe_sense_guard

--- a/esphome/components/grohe_sense_guard/sensor.py
+++ b/esphome/components/grohe_sense_guard/sensor.py
@@ -1,0 +1,38 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    CONF_ID,
+    UNIT_MINUTE,
+    ICON_TIMER,
+)
+from . import grohe_ns, GroheSenseGuard, CONF_GROHE_ID
+
+CONF_SPRINKLER_START = "sprinkler_start_time"
+CONF_SPRINKLER_STOP  = "sprinkler_stop_time"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_GROHE_ID): cv.use_id(GroheSenseGuard),
+        cv.Optional(CONF_SPRINKLER_START): sensor.sensor_schema(
+            unit_of_measurement=UNIT_MINUTE,
+            icon=ICON_TIMER,
+            accuracy_decimals=0,
+        ),
+        cv.Optional(CONF_SPRINKLER_STOP): sensor.sensor_schema(
+            unit_of_measurement=UNIT_MINUTE,
+            icon=ICON_TIMER,
+            accuracy_decimals=0,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_GROHE_ID])
+    if CONF_SPRINKLER_START in config:
+        sens = await sensor.new_sensor(config[CONF_SPRINKLER_START])
+        cg.add(hub.set_sprinkler_start(sens))
+    if CONF_SPRINKLER_STOP in config:
+        sens = await sensor.new_sensor(config[CONF_SPRINKLER_STOP])
+        cg.add(hub.set_sprinkler_stop(sens))

--- a/esphome/components/grohe_sense_guard/text_sensor.py
+++ b/esphome/components/grohe_sense_guard/text_sensor.py
@@ -4,12 +4,16 @@ from esphome.components import text_sensor
 from esphome.const import CONF_ID
 from . import grohe_ns, GroheSenseGuard, CONF_GROHE_ID
 
-CONF_FIRMWARE_VERSION = "firmware_version"
+CONF_FIRMWARE_VERSION   = "firmware_version"
+CONF_LAST_RAW_FRAME     = "last_raw_frame"
+CONF_LAST_UNKNOWN_FRAME = "last_unknown_frame"
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_GROHE_ID): cv.use_id(GroheSenseGuard),
-        cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_FIRMWARE_VERSION):   text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_LAST_RAW_FRAME):     text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_LAST_UNKNOWN_FRAME): text_sensor.text_sensor_schema(),
     }
 )
 
@@ -19,3 +23,9 @@ async def to_code(config):
     if CONF_FIRMWARE_VERSION in config:
         sens = await text_sensor.new_text_sensor(config[CONF_FIRMWARE_VERSION])
         cg.add(hub.set_firmware_version(sens))
+    if CONF_LAST_RAW_FRAME in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_LAST_RAW_FRAME])
+        cg.add(hub.set_last_raw_frame(sens))
+    if CONF_LAST_UNKNOWN_FRAME in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_LAST_UNKNOWN_FRAME])
+        cg.add(hub.set_last_unknown_frame(sens))

--- a/esphome/components/grohe_sense_guard/text_sensor.py
+++ b/esphome/components/grohe_sense_guard/text_sensor.py
@@ -1,0 +1,21 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+from esphome.const import CONF_ID
+from . import grohe_ns, GroheSenseGuard, CONF_GROHE_ID
+
+CONF_FIRMWARE_VERSION = "firmware_version"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_GROHE_ID): cv.use_id(GroheSenseGuard),
+        cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.text_sensor_schema(),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_GROHE_ID])
+    if CONF_FIRMWARE_VERSION in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_FIRMWARE_VERSION])
+        cg.add(hub.set_firmware_version(sens))

--- a/esphome/grohe_tap.yaml
+++ b/esphome/grohe_tap.yaml
@@ -1,0 +1,138 @@
+esphome:
+  name: grohe-tap
+  friendly_name: Grohe Sense Guard Tap
+
+esp32:
+  board: esp32dev
+  framework:
+    type: arduino
+
+# ── WiFi / OTA / API ──────────────────────────────────────────────────────────
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+ota:
+  password: !secret ota_password
+
+api:
+  encryption:
+    key: !secret api_key
+
+logger:
+  level: DEBUG
+
+# ── External component ────────────────────────────────────────────────────────
+external_components:
+  - source:
+      type: local
+      path: components
+
+# ── UART wiring ───────────────────────────────────────────────────────────────
+# Connect to MCU TX line (MCU → ESP8266 direction, also readable for tap).
+# Phase 1 (listen only): connect ESP32 RX to MCU TX.
+# Phase 2 (inject):      connect ESP32 TX to MCU RX (same line as ESP8266 UTXD).
+#
+# WT-8266-S1 pin reference:
+#   URXD = MCU TX → ESP8266 → connect ESP32 RX here
+#   UTXD = ESP8266 TX → MCU RX → connect ESP32 TX here (phase 2 only)
+#
+uart:
+  id: grohe_uart
+  rx_pin: GPIO16   # ESP32 RX ← MCU TX (URXD pad)
+  tx_pin: GPIO17   # ESP32 TX → MCU RX (UTXD pad, phase 2)
+  baud_rate: 115200
+  data_bits: 8
+  stop_bits: 1
+  parity: NONE
+
+# ── Grohe Sense Guard component ───────────────────────────────────────────────
+grohe_sense_guard:
+  id: grohe
+  uart_id: grohe_uart
+
+# ── Binary sensors ────────────────────────────────────────────────────────────
+binary_sensor:
+  - platform: grohe_sense_guard
+    grohe_id: grohe
+
+    valve_open:
+      name: "Grohe Ventil offen"
+      device_class: opening
+
+    snooze_active:
+      name: "Grohe Pause aktiv"
+      device_class: running
+
+    pressure_test:
+      name: "Grohe Drucktest läuft"
+      device_class: running
+
+    sprinkler_monday:
+      name: "Sprinkler Montag"
+    sprinkler_tuesday:
+      name: "Sprinkler Dienstag"
+    sprinkler_wednesday:
+      name: "Sprinkler Mittwoch"
+    sprinkler_thursday:
+      name: "Sprinkler Donnerstag"
+    sprinkler_friday:
+      name: "Sprinkler Freitag"
+    sprinkler_saturday:
+      name: "Sprinkler Samstag"
+    sprinkler_sunday:
+      name: "Sprinkler Sonntag"
+
+# ── Sensors ───────────────────────────────────────────────────────────────────
+sensor:
+  - platform: grohe_sense_guard
+    grohe_id: grohe
+
+    sprinkler_start_time:
+      name: "Sprinkler Startzeit (min)"
+
+    sprinkler_stop_time:
+      name: "Sprinkler Stopzeit (min)"
+
+# ── Text sensors ──────────────────────────────────────────────────────────────
+text_sensor:
+  - platform: grohe_sense_guard
+    grohe_id: grohe
+
+    firmware_version:
+      name: "Grohe Firmware Version"
+
+# ── Buttons (valve control & snooze) ─────────────────────────────────────────
+# These only work reliably in Phase 2 (when Grohe cloud is blocked).
+button:
+  - platform: template
+    name: "Ventil öffnen"
+    on_press:
+      - lambda: 'id(grohe).valve_open();'
+
+  - platform: template
+    name: "Ventil schließen"
+    on_press:
+      - lambda: 'id(grohe).valve_close();'
+
+  - platform: template
+    name: "Pause starten (30 min)"
+    on_press:
+      - lambda: 'id(grohe).snooze_start(30);'
+
+  - platform: template
+    name: "Pause stoppen"
+    on_press:
+      - lambda: 'id(grohe).snooze_stop();'
+
+  - platform: template
+    name: "Sprinkler alle Tage 0:00-23:59"
+    on_press:
+      - lambda: |-
+          bool days[7] = {true, true, true, true, true, true, true};
+          id(grohe).set_sprinkler(0, 1439, days);
+
+  - platform: template
+    name: "Sprinkler aus"
+    on_press:
+      - lambda: 'id(grohe).sprinkler_off();'

--- a/esphome/grohe_tap.yaml
+++ b/esphome/grohe_tap.yaml
@@ -168,3 +168,9 @@ button:
     name: "Sprinkler aus"
     on_press:
       - lambda: 'id(grohe).sprinkler_off();'
+
+  - platform: template
+    name: "Status abrufen"
+    entity_category: diagnostic
+    on_press:
+      - lambda: 'id(grohe).request_status();'

--- a/esphome/grohe_tap.yaml
+++ b/esphome/grohe_tap.yaml
@@ -21,6 +21,25 @@ api:
 
 logger:
   level: DEBUG
+  # Für Protokoll-Analyse: level auf VERBOSE setzen.
+  # Dann erscheinen alle RAW-Frames auch im seriellen Log:
+  # logger:
+  #   level: VERBOSE
+
+# ── Optional: MQTT für Frame-Dump ────────────────────────────────────────────
+# Wenn aktiviert: jedes Frame landet auf grohe/raw_frame
+# → Perfekt zum Aufzeichnen und späteren Analysieren neuer Pakete
+# mqtt:
+#   broker: !secret mqtt_broker
+#   username: !secret mqtt_user
+#   password: !secret mqtt_password
+#   on_connect:
+#     - lambda: |-
+#         id(grohe).add_on_frame_callback([](uint8_t type, uint8_t flags, std::string hex) {
+#           char topic[64];
+#           snprintf(topic, sizeof(topic), "grohe/frame/0x%02X", type);
+#           id(mqtt_client).publish(topic, hex);
+#         });
 
 # ── External component ────────────────────────────────────────────────────────
 external_components:
@@ -101,6 +120,19 @@ text_sensor:
 
     firmware_version:
       name: "Grohe Firmware Version"
+
+    # Jeder empfangene Frame als Hex-String:
+    # "type=0x05 flags=0x20 seq=9 | FE FE FE FE 68 99 ..."
+    # Damit kannst du neue Pakete in HA ablesen und hier analysieren.
+    last_raw_frame:
+      name: "Grohe Letztes Frame (RAW)"
+      entity_category: diagnostic
+
+    # Nur Frames mit unbekanntem type-Byte landen hier.
+    # Wenn Grohe neue Nachrichtentypen schickt, erscheinen sie hier.
+    last_unknown_frame:
+      name: "Grohe Unbekanntes Frame"
+      entity_category: diagnostic
 
 # ── Buttons (valve control & snooze) ─────────────────────────────────────────
 # These only work reliably in Phase 2 (when Grohe cloud is blocked).


### PR DESCRIPTION
## Summary
This PR adds a complete ESPHome integration for the Grohe Sense Guard smart water valve, enabling monitoring and control of the device via UART communication.

## Key Changes

- **Protocol Implementation** (`grohe_protocol.h`): Defines the Grohe proprietary UART protocol with frame structure, message types (INFO, STATUS, CONFIG, HEARTBEAT, WATER_DATA), and helper functions for parsing incoming frames and building outgoing commands.

- **Core Component** (`grohe_sense_guard.h/cpp`): Implements the main `GroheSenseGuard` class that:
  - Manages UART communication with byte-level state machine for frame reception
  - Parses and dispatches different message types (info, status, config)
  - Provides command API for valve control (open/close), snooze management, and sprinkler configuration
  - Publishes sensor data and raw frame diagnostics

- **Sensor Integrations**:
  - `binary_sensor.py`: Exposes valve state, snooze status, pressure test state, and sprinkler schedule (7 days)
  - `sensor.py`: Exposes sprinkler start/stop times in minutes
  - `text_sensor.py`: Exposes firmware version, raw frame hex dumps, and unknown frame diagnostics

- **Example Configuration** (`grohe_tap.yaml`): Complete working example showing UART wiring, sensor setup, and button controls for valve/snooze/sprinkler operations.

## Notable Implementation Details

- **Frame Reception**: Implements timeout-based frame flushing (50ms) and buffer overflow protection (200 byte max)
- **Sequence Tracking**: Maintains device address and sequence numbers for bidirectional communication
- **Config Caching**: Stores last known config payload to enable partial writes (e.g., changing only sprinkler days)
- **Diagnostic Logging**: Supports VERBOSE logging level for protocol analysis and frame capture
- **Callback System**: Allows registration of frame callbacks for custom handling or MQTT publishing
- **Phase 2 Support**: Commands work reliably when Grohe cloud is blocked; includes safety notes in configuration

https://claude.ai/code/session_014ddy1uWXvRhtvSD9oUf5RS